### PR TITLE
fix: signal hash and message sender comparator

### DIFF
--- a/docs/proof.md
+++ b/docs/proof.md
@@ -133,7 +133,7 @@ contract AnonAadhaarVote is IAnonAadhaarVote {
 
     /// @dev Convert an address to uint256, used to check against signal.
     /// @param _addr: msg.sender address.
-    /// @return Address msg.sender's address in uint256
+    /// @return Address msg.sender's hashed address in uint256
     function signalHashVerifier(address _addr) private pure returns (uint256) {
          // Convert address to uint256
         uint256 addrAsUint = uint256(uint160(_addr));

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -134,8 +134,18 @@ contract AnonAadhaarVote is IAnonAadhaarVote {
     /// @dev Convert an address to uint256, used to check against signal.
     /// @param _addr: msg.sender address.
     /// @return Address msg.sender's address in uint256
-    function addressToUint256(address _addr) private pure returns (uint256) {
-        return uint256(uint160(_addr));
+    function signalHashVerifier(address _addr) private pure returns (uint256) {
+         // Convert address to uint256
+        uint256 addrAsUint = uint256(uint160(_addr));
+        
+        // Pad to 32 bytes (256 bits)
+        bytes32 paddedAddr = bytes32(addrAsUint);
+        
+        // Apply keccak256 hash
+        bytes32 hashed = keccak256(abi.encodePacked(paddedAddr));
+        
+        // Shift right by 3 bits and return
+        return uint256(hashed) >> 3;
     }
 
     /// @dev Check if the timestamp is more recent than (current time - 3 hours)
@@ -167,7 +177,7 @@ contract AnonAadhaarVote is IAnonAadhaarVote {
             '[AnonAadhaarVote]: Invalid proposal index'
         );
         require(
-            addressToUint256(msg.sender) == signal,
+            signalHashVerifier(msg.sender) == signal,
             '[AnonAadhaarVote]: wrong user signal sent.'
         );
         require(


### PR DESCRIPTION
```solidity
function addressToUint256(address _addr) private pure returns (uint256) {
        return uint256(uint160(_addr));
    }    
```

```solidity
require(
            addressToUint256(msg.sender) == signal,
            '[AnonAadhaarVote]: wrong user signal sent.'
        );
```
Will always fail because the way the signal hash is generated by the library 


```typescript
import { BigNumber } from '@ethersproject/bignumber'
import { BytesLike, Hexable, zeroPad } from '@ethersproject/bytes'
import { keccak256 } from '@ethersproject/keccak256'
import { NumericString } from 'snarkjs'

/**
 * Creates a keccak256 hash of a message compatible with the SNARK scalar modulus.
 * @param message The message to be hashed.
 * @returns The message digest.
 */
export function hash(
  message: BytesLike | Hexable | number | bigint
): NumericString {
  message = BigNumber.from(message).toTwos(256).toHexString()

  message = zeroPad(message, 32)

  return (BigInt(keccak256(message)) >> BigInt(3)).toString() as NumericString
}
```

Fixed by
 ```solidity
     function signalHashVerifier(address _addr) private pure returns (uint256) {
         // Convert address to uint256
        uint256 addrAsUint = uint256(uint160(_addr));

        // Pad to 32 bytes (256 bits)
        bytes32 paddedAddr = bytes32(addrAsUint);

        // Apply keccak256 hash
        bytes32 hashed = keccak256(abi.encodePacked(paddedAddr));

        // Shift right by 3 bits and return
        return uint256(hashed) >> 3;
    }
 ```